### PR TITLE
Fix champion grid overlap in generator layout

### DIFF
--- a/app/[seed]/ChampionGrid.tsx
+++ b/app/[seed]/ChampionGrid.tsx
@@ -1,34 +1,77 @@
-import {
-  Champion,
-  CHAMPION_IMAGE_ENDPOINT,
-  fetchChampions,
-} from '@/lib/lol-api';
-import React from 'react';
+import { Champion, getChampionImageUrl } from '@/lib/lol-api';
 import Image from 'next/image';
 import { twMerge } from 'tailwind-merge';
 
 interface Props {
   champions: Champion[];
+  roleLabels: Record<string, string>;
   rtl?: boolean;
 }
 
-const ChampionGrid: React.FC<Props> = ({ champions, rtl = false }) => {
+const ChampionGrid = ({ champions, roleLabels, rtl = false }: Props) => {
   return (
-    <ul className={twMerge('grid grid-cols-2 gap-4 p-4', rtl && '[direction:rtl]')}>
-      {champions.map((champion) => (
+    <ul
+      className={twMerge(
+        'grid gap-4 p-3 sm:p-4 [grid-template-columns:repeat(auto-fit,minmax(15rem,1fr))]',
+        rtl && '[direction:rtl] text-right',
+      )}
+    >
+      {champions.map((champion, index) => (
         <li
           key={champion.id}
-          className={twMerge('flex w-48 items-center justify-start bg-gray-800 p-2 rounded-lg shadow-md')}
+          className={twMerge(
+            'group relative flex w-full items-center gap-4 overflow-hidden rounded-2xl border border-white/10 bg-slate-900/70 p-4 shadow-[0_20px_45px_rgba(2,6,23,0.45)] transition-transform duration-200 hover:-translate-y-1 hover:border-amber-300/40 hover:shadow-[0_28px_65px_rgba(240,171,0,0.35)]',
+            rtl && 'flex-row-reverse text-right'
+          )}
         >
-          <div className={twMerge('relative h-16 w-16 flex-shrink-0 rounded-md overflow-hidden')}>
+          <div className="absolute inset-0 -z-10 opacity-0 transition-opacity duration-200 group-hover:opacity-100">
+            <div className="absolute inset-0 bg-[radial-gradient(circle_at_center,_rgba(250,204,21,0.2),_transparent_65%)]" />
+          </div>
+          <span
+            className={twMerge(
+              'flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full border border-amber-300/40 bg-slate-950/80 text-xs font-bold uppercase tracking-[0.2em] text-amber-200 shadow-inner',
+              rtl && 'order-3'
+            )}
+          >
+            {index + 1}
+          </span>
+          <div
+            className={twMerge(
+              'relative h-16 w-16 flex-shrink-0 overflow-hidden rounded-xl border border-white/10 bg-slate-950/60 shadow-inner sm:h-20 sm:w-20',
+              rtl && 'order-2'
+            )}
+          >
             <Image
-              src={`${CHAMPION_IMAGE_ENDPOINT}/${champion.image.full}`}
+              src={getChampionImageUrl(champion)}
               alt={`${champion.name} splash art`}
               fill
-              priority
+              priority={index < 4}
+              sizes="4rem"
+              unoptimized
             />
           </div>
-          <h2 className={twMerge('mx-4 text-white font-semibold')}>{champion.name}</h2>
+          <div
+            className={twMerge(
+              'flex min-w-0 flex-1 flex-col gap-1.5',
+              rtl ? 'items-end text-right' : 'items-start text-left'
+            )}
+          >
+            <h2 className="truncate text-sm font-semibold text-white sm:text-base">
+              {champion.name}
+            </h2>
+            {champion.tags?.length ? (
+              <div className={twMerge('flex flex-wrap gap-1.5', rtl && 'justify-end')}>
+                {champion.tags.map((tag) => (
+                  <span
+                    key={`${champion.id}-${tag}`}
+                    className="badge badge-outline badge-sm border-amber-200/40 bg-slate-950/60 px-2 py-0.5 text-[0.65rem] uppercase tracking-wide text-amber-100"
+                  >
+                    {roleLabels[tag] ?? tag}
+                  </span>
+                ))}
+              </div>
+            ) : null}
+          </div>
         </li>
       ))}
     </ul>

--- a/app/[seed]/LanguageSelector.tsx
+++ b/app/[seed]/LanguageSelector.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { ChangeEvent, useCallback } from 'react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import {
+  DEFAULT_LANGUAGE,
+  LanguageKey,
+  LanguageSelectorTranslations,
+} from '@/lib/i18n';
+
+interface LanguageSelectorProps {
+  language: LanguageKey;
+  translations: LanguageSelectorTranslations;
+}
+
+const LanguageSelector = ({ language, translations }: LanguageSelectorProps) => {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const handleChange = useCallback(
+    (event: ChangeEvent<HTMLSelectElement>) => {
+      const nextLanguage = event.target.value as LanguageKey;
+      const params = new URLSearchParams(searchParams?.toString());
+
+      if (nextLanguage === DEFAULT_LANGUAGE) {
+        params.delete('lang');
+      } else {
+        params.set('lang', nextLanguage);
+      }
+
+      const query = params.toString();
+      const target = query ? `${pathname}?${query}` : pathname;
+
+      router.replace(target);
+    },
+    [pathname, router, searchParams],
+  );
+
+  return (
+    <label className="flex w-full flex-col gap-2 rounded-2xl border border-white/10 bg-slate-950/70 p-4 text-left text-[0.6rem] font-semibold uppercase tracking-[0.35em] text-slate-200 shadow-[0_12px_28px_rgba(2,6,23,0.45)]">
+      <span>{translations.label}</span>
+      <select
+        value={language}
+        onChange={handleChange}
+        className="select select-sm w-full border border-white/10 bg-slate-900/80 text-xs uppercase tracking-[0.2em] text-slate-100"
+        aria-label={translations.label}
+      >
+        {Object.entries(translations.options).map(([value, label]) => (
+          <option key={value} value={value} className="text-base normal-case">
+            {label}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+};
+
+export default LanguageSelector;

--- a/app/[seed]/MatchupInsights.tsx
+++ b/app/[seed]/MatchupInsights.tsx
@@ -1,0 +1,91 @@
+import { MatchupInsightsTranslations } from '@/lib/i18n';
+import { Champion } from '@/lib/lol-api';
+
+interface MatchupInsightsProps {
+  left: Champion[];
+  right: Champion[];
+  translations: MatchupInsightsTranslations;
+}
+
+const METRICS = ['attack', 'defense', 'magic', 'difficulty'] as const;
+
+type MetricKey = (typeof METRICS)[number];
+
+const toFixed = (value: number) => Math.round(value * 10) / 10;
+
+const getAverage = (team: Champion[], key: MetricKey) => {
+  if (team.length === 0) {
+    return 0;
+  }
+
+  const total = team.reduce((sum, champion) => {
+    const stat = champion.info?.[key] ?? 0;
+    return sum + stat;
+  }, 0);
+
+  return toFixed(total / team.length);
+};
+
+const MatchupInsights = ({ left, right, translations }: MatchupInsightsProps) => {
+  if (!left.length && !right.length) {
+    return null;
+  }
+
+  return (
+    <section className="flex w-full flex-col gap-4 rounded-2xl border border-white/10 bg-slate-950/70 p-6 text-left text-sm text-slate-200 shadow-[0_15px_40px_rgba(8,47,73,0.35)] backdrop-blur">
+      <div>
+        <h3 className="text-[0.65rem] font-semibold uppercase tracking-[0.4em] text-slate-200">
+          {translations.heading}
+        </h3>
+        <p className="mt-2 text-[0.65rem] text-slate-300/80">{translations.helper}</p>
+      </div>
+      <dl className="flex flex-col gap-4">
+        {METRICS.map((metric) => {
+          const leftAverage = getAverage(left, metric);
+          const rightAverage = getAverage(right, metric);
+          const maxValue = Math.max(leftAverage, rightAverage, 1);
+          const leftRatio = Math.max(0, Math.min((leftAverage / maxValue) * 100, 100));
+          const rightRatio = Math.max(0, Math.min((rightAverage / maxValue) * 100, 100));
+
+          return (
+            <div key={metric} className="flex flex-col gap-2">
+              <dt className="text-[0.55rem] uppercase tracking-[0.35em] text-slate-300">
+                {translations.metrics[metric]}
+              </dt>
+              <dd className="grid grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-3">
+                <div className="flex flex-col items-end">
+                  <span className="text-[0.55rem] uppercase tracking-[0.35em] text-amber-200/80">
+                    {translations.leftLabel}
+                  </span>
+                  <span className="text-sm font-semibold text-amber-200">
+                    {leftAverage.toFixed(1)}
+                  </span>
+                </div>
+                <div className="relative h-2 w-full overflow-hidden rounded-full bg-slate-800/70">
+                  <span
+                    className="absolute inset-y-0 left-0 rounded-full bg-gradient-to-r from-amber-200 via-amber-300 to-amber-500"
+                    style={{ width: `${leftRatio}%` }}
+                  />
+                  <span
+                    className="absolute inset-y-0 right-0 rounded-full bg-gradient-to-l from-sky-200 via-sky-300 to-sky-500"
+                    style={{ width: `${rightRatio}%` }}
+                  />
+                </div>
+                <div className="flex flex-col">
+                  <span className="text-[0.55rem] uppercase tracking-[0.35em] text-sky-200/80">
+                    {translations.rightLabel}
+                  </span>
+                  <span className="text-sm font-semibold text-sky-200">
+                    {rightAverage.toFixed(1)}
+                  </span>
+                </div>
+              </dd>
+            </div>
+          );
+        })}
+      </dl>
+    </section>
+  );
+};
+
+export default MatchupInsights;

--- a/app/[seed]/SeedActions.tsx
+++ b/app/[seed]/SeedActions.tsx
@@ -1,0 +1,194 @@
+'use client';
+
+import { SeedActionsTranslations } from '@/lib/i18n';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+interface SeedActionsProps {
+  seed: string;
+  teamSize: number;
+  sharePath: string;
+  matchup: {
+    left: { name: string }[];
+    right: { name: string }[];
+  };
+  translations: SeedActionsTranslations;
+}
+
+type FeedbackState = {
+  message: string;
+  tone: 'success' | 'error';
+};
+
+const FEEDBACK_DURATION_MS = 2500;
+
+type ShareCapableNavigator = Navigator & {
+  share: (data?: ShareData) => Promise<void>;
+};
+
+const canShare = (nav: Navigator): nav is ShareCapableNavigator =>
+  typeof (nav as ShareCapableNavigator).share === 'function';
+
+const buildMatchupSummary = (
+  seed: string,
+  teamSize: number,
+  matchup: SeedActionsProps['matchup'],
+  summaryTranslations: SeedActionsTranslations['summary'],
+): string => {
+  const lines = [
+    `${summaryTranslations.seed}: ${seed}`,
+    `${summaryTranslations.championsPerTeam}: ${teamSize}`,
+    '',
+    `${summaryTranslations.teamLabel} 1 (${matchup.left.length}): ${matchup.left
+      .map((champion) => champion.name)
+      .join(', ')}`,
+    `${summaryTranslations.teamLabel} 2 (${matchup.right.length}): ${matchup.right
+      .map((champion) => champion.name)
+      .join(', ')}`,
+  ];
+
+  return lines.join('\n');
+};
+
+const SeedActions: React.FC<SeedActionsProps> = ({
+  seed,
+  teamSize,
+  sharePath,
+  matchup,
+  translations,
+}) => {
+  const [feedback, setFeedback] = useState<FeedbackState | null>(null);
+  const resetTimeoutRef = useRef<number>();
+
+  const shareUrl = useMemo(() => {
+    if (typeof window === 'undefined') {
+      return sharePath;
+    }
+
+    const origin = window.location.origin.replace(/\/$/, '');
+    return `${origin}${sharePath}`;
+  }, [sharePath]);
+
+  const matchupSummary = useMemo(
+    () => buildMatchupSummary(seed, teamSize, matchup, translations.summary),
+    [seed, teamSize, matchup, translations],
+  );
+
+  const scheduleFeedbackReset = useCallback(() => {
+    if (resetTimeoutRef.current) {
+      window.clearTimeout(resetTimeoutRef.current);
+    }
+
+    resetTimeoutRef.current = window.setTimeout(() => {
+      setFeedback(null);
+    }, FEEDBACK_DURATION_MS);
+  }, []);
+
+  const showFeedback = useCallback((message: string, tone: FeedbackState['tone']) => {
+    setFeedback({ message, tone });
+    scheduleFeedbackReset();
+  }, [scheduleFeedbackReset]);
+
+  const handleCopy = useCallback(async () => {
+    try {
+      if (!navigator.clipboard) {
+        showFeedback(translations.clipboardUnavailable, 'error');
+        return;
+      }
+
+      await navigator.clipboard.writeText(shareUrl);
+      showFeedback(translations.seedCopied, 'success');
+    } catch (error) {
+      console.error('Failed to copy seed', error);
+      showFeedback(translations.seedCopyError, 'error');
+    }
+  }, [shareUrl, showFeedback, translations]);
+
+  const handleCopyMatchup = useCallback(async () => {
+    try {
+      if (!navigator.clipboard) {
+        showFeedback(translations.clipboardUnavailable, 'error');
+        return;
+      }
+
+      await navigator.clipboard.writeText(matchupSummary);
+      showFeedback(translations.matchupCopied, 'success');
+    } catch (error) {
+      console.error('Failed to copy matchup', error);
+      showFeedback(translations.matchupCopyError, 'error');
+    }
+  }, [matchupSummary, showFeedback, translations]);
+
+  const handleShare = useCallback(async () => {
+    try {
+      if (canShare(navigator)) {
+        await navigator.share({
+          url: shareUrl,
+          text: matchupSummary,
+          title: translations.shareTitle,
+        });
+        showFeedback(translations.shareSuccess, 'success');
+        return;
+      }
+
+      await handleCopy();
+    } catch (error) {
+      console.error('Failed to share seed', error);
+      showFeedback(translations.shareFailure, 'error');
+    }
+  }, [handleCopy, shareUrl, matchupSummary, showFeedback, translations]);
+
+  useEffect(() => {
+    return () => {
+      if (resetTimeoutRef.current) {
+        window.clearTimeout(resetTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  return (
+    <div className="flex w-full flex-col items-center gap-3 rounded-2xl border border-white/10 bg-white/5 p-5 text-center shadow-[0_15px_40px_rgba(8,47,73,0.35)]">
+      <p className="text-[0.6rem] uppercase tracking-[0.4em] text-slate-200">
+        {translations.seedLabel}
+      </p>
+      <code className="rounded-full border border-amber-200/40 bg-slate-950/70 px-4 py-2 text-sm font-semibold tracking-widest text-amber-200 shadow-inner sm:text-base">
+        {seed}
+      </code>
+      <div className="flex flex-wrap justify-center gap-2">
+        <button
+          type="button"
+          className="btn btn-outline btn-sm border-amber-200/60 text-amber-200 hover:border-amber-100 hover:bg-amber-300/10"
+          onClick={handleCopy}
+        >
+          {translations.copyLink}
+        </button>
+        <button
+          type="button"
+          className="btn btn-outline btn-sm border-white/30 text-slate-100 hover:border-white/60 hover:bg-slate-800/60"
+          onClick={handleShare}
+        >
+          {translations.share}
+        </button>
+        <button
+          type="button"
+          className="btn btn-outline btn-sm border-white/30 text-slate-100 hover:border-white/60 hover:bg-slate-800/60"
+          onClick={handleCopyMatchup}
+        >
+          {translations.copyMatchup}
+        </button>
+      </div>
+      {feedback ? (
+        <p
+          className={
+            feedback.tone === 'success'
+              ? 'text-xs font-medium text-emerald-300'
+              : 'text-xs font-medium text-rose-300'
+          }
+        >
+          {feedback.message}
+        </p>
+      ) : null}
+    </div>
+  );
+};
+
+export default SeedActions;

--- a/app/[seed]/TeamControls.tsx
+++ b/app/[seed]/TeamControls.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import { ChangeEvent, useCallback } from 'react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { TeamControlsTranslations } from '@/lib/i18n';
+
+interface TeamControlsProps {
+  teamSize: number;
+  defaultTeamSize: number;
+  minTeamSize: number;
+  maxTeamSize: number;
+  translations: TeamControlsTranslations;
+}
+
+const clamp = (value: number, min: number, max: number) =>
+  Math.min(Math.max(value, min), max);
+
+const TeamControls = ({
+  teamSize,
+  defaultTeamSize,
+  minTeamSize,
+  maxTeamSize,
+  translations,
+}: TeamControlsProps) => {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const pushTeamSize = useCallback(
+    (value: number) => {
+      const nextSize = clamp(value, minTeamSize, maxTeamSize);
+      const params = new URLSearchParams(searchParams?.toString());
+
+      if (nextSize === defaultTeamSize) {
+        params.delete('size');
+      } else {
+        params.set('size', String(nextSize));
+      }
+
+      const query = params.toString();
+      const target = query ? `${pathname}?${query}` : pathname;
+
+      router.replace(target);
+    },
+    [defaultTeamSize, maxTeamSize, minTeamSize, pathname, router, searchParams],
+  );
+
+  const handleInputChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      pushTeamSize(Number(event.target.value));
+    },
+    [pushTeamSize],
+  );
+
+  const handleDecrease = useCallback(() => {
+    pushTeamSize(teamSize - 1);
+  }, [pushTeamSize, teamSize]);
+
+  const handleIncrease = useCallback(() => {
+    pushTeamSize(teamSize + 1);
+  }, [pushTeamSize, teamSize]);
+
+  return (
+    <section className="flex w-full flex-col items-center gap-4 rounded-2xl border border-white/10 bg-gradient-to-br from-slate-900/80 via-slate-900/60 to-slate-900/40 p-6 text-center shadow-[0_20px_45px_rgba(2,6,23,0.55)] backdrop-blur">
+      <h3 className="text-[0.65rem] font-semibold uppercase tracking-[0.4em] text-slate-200">
+        {translations.heading}
+      </h3>
+      <div className="flex w-full flex-col gap-3">
+        <div className="flex items-center justify-center gap-3">
+          <button
+            type="button"
+            className="btn btn-circle btn-xs border-white/20 text-lg"
+            onClick={handleDecrease}
+            disabled={teamSize <= minTeamSize}
+            aria-label={translations.decreaseAria}
+          >
+            –
+          </button>
+          <div>
+            <p className="text-[0.6rem] uppercase tracking-[0.35em] text-slate-300">
+              {translations.championsPerTeam}
+            </p>
+            <p className="text-3xl font-bold text-yellow-300 drop-shadow-[0_0_12px_rgba(234,179,8,0.35)]">
+              {teamSize}
+            </p>
+          </div>
+          <button
+            type="button"
+            className="btn btn-circle btn-xs border-white/20 text-lg"
+            onClick={handleIncrease}
+            disabled={teamSize >= maxTeamSize}
+            aria-label={translations.increaseAria}
+          >
+            +
+          </button>
+        </div>
+        <input
+          type="range"
+          min={minTeamSize}
+          max={maxTeamSize}
+          value={teamSize}
+          onChange={handleInputChange}
+          className="range range-xs"
+          aria-label={translations.rangeAria}
+        />
+        <div className="flex w-full justify-between text-[0.55rem] uppercase tracking-[0.4em] text-slate-400">
+          <span>{minTeamSize}</span>
+          <span>{defaultTeamSize}</span>
+          <span>{maxTeamSize}</span>
+        </div>
+      </div>
+      <p className="text-[0.65rem] text-slate-200/80">
+        {translations.helper}
+      </p>
+    </section>
+  );
+};
+
+export default TeamControls;

--- a/app/[seed]/TeamSummary.tsx
+++ b/app/[seed]/TeamSummary.tsx
@@ -1,0 +1,97 @@
+import { TeamSummaryTranslations } from '@/lib/i18n';
+import { Champion } from '@/lib/lol-api';
+
+interface TeamSummaryProps {
+  champions: Champion[];
+  translations: TeamSummaryTranslations;
+}
+
+const toFixed = (value: number) => Math.round(value * 10) / 10;
+
+const TeamSummary = ({ champions, translations }: TeamSummaryProps) => {
+  if (champions.length === 0) {
+    return null;
+  }
+
+  const roleCounts = champions.reduce<Record<string, number>>((counts, champion) => {
+    if (!champion.tags || champion.tags.length === 0) {
+      counts.Unknown = (counts.Unknown ?? 0) + 1;
+      return counts;
+    }
+
+    champion.tags.forEach((tag) => {
+      counts[tag] = (counts[tag] ?? 0) + 1;
+    });
+
+    return counts;
+  }, {});
+
+  const sortedRoles = Object.entries(roleCounts).sort(([, left], [, right]) =>
+    right - left,
+  );
+
+  const averageDifficulty = champions.reduce((total, champion) => {
+    return total + (champion.info?.difficulty ?? 0);
+  }, 0);
+
+  const difficultyScore = champions.length
+    ? toFixed(averageDifficulty / champions.length)
+    : 0;
+
+  const maxRoleCount = sortedRoles[0]?.[1] ?? 1;
+
+  return (
+    <aside className="w-full rounded-2xl border border-white/10 bg-slate-950/70 p-5 text-left text-sm text-slate-200 shadow-[0_12px_32px_rgba(2,6,23,0.45)] backdrop-blur">
+      <h3 className="mb-3 text-[0.65rem] font-semibold uppercase tracking-[0.4em] text-slate-300">
+        {translations.heading}
+      </h3>
+      <dl className="flex flex-col gap-4">
+        <div className="flex items-center justify-between gap-3 rounded-xl border border-white/5 bg-white/5 px-4 py-3">
+          <dt className="text-[0.55rem] uppercase tracking-[0.35em] text-slate-300">
+            {translations.uniqueRoles}
+          </dt>
+          <dd className="text-lg font-semibold text-amber-200 drop-shadow-[0_0_10px_rgba(250,204,21,0.35)]">
+            {sortedRoles.length}
+          </dd>
+        </div>
+        <div className="flex flex-col gap-3">
+          <dt className="text-[0.55rem] uppercase tracking-[0.35em] text-slate-300">
+            {translations.roleDistribution}
+          </dt>
+          <dd className="flex flex-col gap-2">
+            {sortedRoles.map(([role, count]) => {
+              const percentage = (count / maxRoleCount) * 100;
+              return (
+                <div
+                  key={role}
+                  className="flex items-center gap-3 rounded-lg border border-white/5 bg-slate-900/70 px-3 py-2"
+                >
+                  <span className="w-24 text-[0.6rem] uppercase tracking-[0.3em] text-slate-300">
+                    {translations.roleLabels[role] ?? role}
+                  </span>
+                  <div className="relative h-2 flex-1 overflow-hidden rounded-full bg-slate-800/70">
+                    <span
+                      className="absolute inset-y-0 left-0 rounded-full bg-gradient-to-r from-amber-200 via-amber-300 to-amber-500"
+                      style={{ width: `${percentage}%` }}
+                    />
+                  </div>
+                  <span className="text-xs font-semibold text-amber-100">{count}</span>
+                </div>
+              );
+            })}
+          </dd>
+        </div>
+        <div className="flex items-center justify-between gap-3 rounded-xl border border-white/5 bg-emerald-400/10 px-4 py-3">
+          <dt className="text-[0.55rem] uppercase tracking-[0.35em] text-slate-300">
+            {translations.averageDifficulty}
+          </dt>
+          <dd className="text-lg font-semibold text-emerald-200">
+            {difficultyScore}
+          </dd>
+        </div>
+      </dl>
+    </aside>
+  );
+};
+
+export default TeamSummary;

--- a/app/[seed]/page.tsx
+++ b/app/[seed]/page.tsx
@@ -1,9 +1,15 @@
 import arraySample from '@/lib/array-sample';
 import generateSeed from '@/lib/generate-seed';
+import { DEFAULT_LANGUAGE, LanguageKey, getDictionary, resolveLanguage } from '@/lib/i18n';
 import { fetchChampions } from '@/lib/lol-api';
 import Link from 'next/link';
 import { use } from 'react';
 import ChampionGrid from './ChampionGrid';
+import LanguageSelector from './LanguageSelector';
+import MatchupInsights from './MatchupInsights';
+import SeedActions from './SeedActions';
+import TeamControls from './TeamControls';
+import TeamSummary from './TeamSummary';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'experimental-edge';
@@ -12,35 +18,144 @@ interface Props {
   params: {
     seed: string;
   };
+  searchParams?: {
+    size?: string;
+    lang?: string;
+  };
 }
 
-const poolSize = 20;
+const DEFAULT_TEAM_SIZE = 15;
+const MIN_TEAM_SIZE = 10;
+const MAX_TEAM_SIZE = 20;
 
-const Page: React.FC<Props> = ({ params }) => {
+const clampTeamSize = (value: number) =>
+  Math.min(Math.max(value, MIN_TEAM_SIZE), MAX_TEAM_SIZE);
+
+const resolveTeamSize = (rawSize?: string) => {
+  if (!rawSize) {
+    return DEFAULT_TEAM_SIZE;
+  }
+
+  const parsed = Number.parseInt(rawSize, 10);
+
+  if (!Number.isFinite(parsed)) {
+    return DEFAULT_TEAM_SIZE;
+  }
+
+  return clampTeamSize(parsed);
+};
+
+const buildSharePath = (seed: string, teamSize: number, language: LanguageKey) => {
+  const params = new URLSearchParams();
+
+  if (teamSize !== DEFAULT_TEAM_SIZE) {
+    params.set('size', String(teamSize));
+  }
+
+  if (language !== DEFAULT_LANGUAGE) {
+    params.set('lang', language);
+  }
+
+  const query = params.toString();
+
+  return query ? `/${seed}?${query}` : `/${seed}`;
+};
+
+const Page = ({ params, searchParams }: Props) => {
   const data = use(fetchChampions());
+
+  const teamSize = resolveTeamSize(searchParams?.size);
+  const poolSize = teamSize * 2;
+
+  const language = resolveLanguage(searchParams?.lang);
+  const dictionary = getDictionary(language);
 
   const pool = arraySample(data, poolSize, params.seed);
 
   const left = pool.slice(0, Math.floor(poolSize / 2));
   const right = pool.slice(Math.floor(poolSize / 2));
 
+  const sharePath = buildSharePath(params.seed, teamSize, language);
+
   return (
-    <main className="container mx-auto flex flex-col min-h-screen w-full items-center justify-center p-8">
-      <h1 className="text-3xl font-bold text-yellow-500 mb-8 text-center">lilwang ng...</h1>
-      <div className="flex w-full items-center justify-center">
-        <div className="flex flex-col items-center">
-          <h2 className="text-2xl font-bold text-white mb-4">Team 1</h2>
-          <ChampionGrid champions={left} />
-        </div>
-        <div className="mx-8 flex flex-col items-center justify-center gap-4">
-          <Link href={`/${generateSeed()}`} className="btn btn-outline btn-sm">
-            Regenerate
-          </Link>
-        </div>
-        <div className="flex flex-col items-center">
-          <h2 className="text-2xl font-bold text-white mb-4">Team 2</h2>
-          <ChampionGrid champions={right} rtl />
-        </div>
+    <main className="relative min-h-screen w-full overflow-hidden bg-gradient-to-b from-slate-950 via-slate-900 to-slate-950">
+      <div className="pointer-events-none absolute inset-0 -z-10">
+        <div className="absolute left-1/2 top-[-15%] h-[32rem] w-[120%] -translate-x-1/2 rounded-full bg-[radial-gradient(circle_at_center,_rgba(250,204,21,0.18),_transparent_60%)] blur-3xl" />
+        <div className="absolute bottom-[-30%] left-[5%] h-[28rem] w-[50rem] rounded-full bg-[radial-gradient(circle_at_center,_rgba(56,189,248,0.2),_transparent_65%)] blur-3xl" />
+      </div>
+      <div className="container relative mx-auto flex min-h-screen w-full flex-col items-center justify-center gap-10 p-6 sm:p-10">
+        <header className="flex flex-col items-center gap-3 text-center">
+          <h1 className="text-3xl font-bold text-yellow-300 drop-shadow-[0_0_18px_rgba(234,179,8,0.45)] sm:text-5xl">
+            {dictionary.page.title}
+          </h1>
+          <p className="max-w-2xl text-sm text-slate-200 sm:text-base">
+            {dictionary.page.description}
+          </p>
+        </header>
+        <section className="grid w-full max-w-6xl grid-cols-1 gap-8 xl:grid-cols-[minmax(0,1fr)_minmax(19rem,22rem)_minmax(0,1fr)] xl:items-start">
+          <div className="flex w-full flex-col gap-5">
+            <div className="rounded-3xl border border-white/10 bg-white/5 p-6 shadow-[0_25px_60px_rgba(15,23,42,0.45)] backdrop-blur">
+              <div className="mb-4 flex items-center justify-between">
+                <div>
+                  <p className="text-xs uppercase tracking-[0.3em] text-slate-300">
+                    {dictionary.page.teamLabel} 1
+                  </p>
+                  <h2 className="text-2xl font-semibold text-white sm:text-3xl">
+                    {left.length} {dictionary.page.championCountLabel}
+                  </h2>
+                </div>
+                <span className="rounded-full bg-gradient-to-br from-amber-400/90 to-amber-500/80 px-4 py-1 text-xs font-bold uppercase tracking-[0.2em] text-slate-950 shadow-lg">
+                  {dictionary.page.leftBadge}
+                </span>
+              </div>
+              <ChampionGrid champions={left} roleLabels={dictionary.teamSummary.roleLabels} />
+            </div>
+            <TeamSummary champions={left} translations={dictionary.teamSummary} />
+          </div>
+          <div className="flex flex-col items-center gap-6 rounded-3xl border border-white/10 bg-slate-950/80 p-6 shadow-[0_25px_60px_rgba(8,47,73,0.35)] backdrop-blur">
+            <LanguageSelector language={language} translations={dictionary.languageSelector} />
+            <SeedActions
+              seed={params.seed}
+              teamSize={teamSize}
+              sharePath={sharePath}
+              matchup={{ left, right }}
+              translations={dictionary.seedActions}
+            />
+            <TeamControls
+              teamSize={teamSize}
+              defaultTeamSize={DEFAULT_TEAM_SIZE}
+              minTeamSize={MIN_TEAM_SIZE}
+              maxTeamSize={MAX_TEAM_SIZE}
+              translations={dictionary.teamControls}
+            />
+            <MatchupInsights left={left} right={right} translations={dictionary.matchupInsights} />
+            <Link
+              href={buildSharePath(generateSeed(), teamSize, language)}
+              className="btn btn-outline btn-wide"
+            >
+              {dictionary.page.regenerate}
+            </Link>
+          </div>
+          <div className="flex w-full flex-col gap-5">
+            <div className="rounded-3xl border border-white/10 bg-white/5 p-6 shadow-[0_25px_60px_rgba(15,23,42,0.45)] backdrop-blur">
+              <div className="mb-4 flex items-center justify-between">
+                <span className="rounded-full bg-gradient-to-br from-sky-400/90 to-sky-500/80 px-4 py-1 text-xs font-bold uppercase tracking-[0.2em] text-slate-950 shadow-lg">
+                  {dictionary.page.rightBadge}
+                </span>
+                <div className="text-right">
+                  <p className="text-xs uppercase tracking-[0.3em] text-slate-300">
+                    {dictionary.page.teamLabel} 2
+                  </p>
+                  <h2 className="text-2xl font-semibold text-white sm:text-3xl">
+                    {right.length} {dictionary.page.championCountLabel}
+                  </h2>
+                </div>
+              </div>
+              <ChampionGrid champions={right} roleLabels={dictionary.teamSummary.roleLabels} rtl />
+            </div>
+            <TeamSummary champions={right} translations={dictionary.teamSummary} />
+          </div>
+        </section>
       </div>
     </main>
   );

--- a/lib/array-sample.ts
+++ b/lib/array-sample.ts
@@ -2,21 +2,34 @@ import seedrandom from 'seedrandom';
 import generateSeed from './generate-seed';
 
 export default function getRandom<T>(
-  arr: Array<T>,
+  arr: readonly T[],
   n: number,
   seed: string = generateSeed(),
-): Array<T> {
-  var rng = seedrandom(seed);
-
-  var result = new Array(n),
-    len = arr.length,
-    taken = new Array(len);
-  if (n > len)
-    throw new RangeError('getRandom: more elements taken than available');
-  while (n--) {
-    var x = Math.floor(rng() * len);
-    result[n] = arr[x in taken ? taken[x] : x];
-    taken[x] = --len in taken ? taken[len] : len;
+): T[] {
+  if (!Number.isInteger(n) || n < 0) {
+    throw new RangeError('getRandom: n must be a non-negative integer');
   }
+
+  const len = arr.length;
+
+  if (n > len) {
+    throw new RangeError('getRandom: more elements taken than available');
+  }
+
+  const rng = seedrandom(seed);
+  const result = new Array<T>(n);
+  const taken = new Array<number>(len);
+  let remaining = len;
+
+  for (let index = n - 1; index >= 0; index -= 1) {
+    const randomIndex = Math.floor(rng() * remaining);
+    const selectedIndex = taken[randomIndex] ?? randomIndex;
+
+    result[index] = arr[selectedIndex];
+
+    remaining -= 1;
+    taken[randomIndex] = taken[remaining] ?? remaining;
+  }
+
   return result;
 }

--- a/lib/generate-seed.ts
+++ b/lib/generate-seed.ts
@@ -1,8 +1,44 @@
-export default function generateSeed(length = 15, characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789') {
-  let result = '';
-  const charactersLength = characters.length;
-  for (let i = 0; i < length; i++) {
-    result += characters.charAt(Math.floor(Math.random() * charactersLength));
+const DEFAULT_LENGTH = 15;
+const DEFAULT_CHARSET =
+  'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+
+type CryptoEnabledGlobal = typeof globalThis & {
+  crypto?: Crypto;
+};
+
+const getRandomValues = (length: number): Uint8Array => {
+  const cryptoObj = (globalThis as CryptoEnabledGlobal).crypto;
+
+  if (cryptoObj && typeof cryptoObj.getRandomValues === 'function') {
+    const buffer = new Uint8Array(length);
+    cryptoObj.getRandomValues(buffer);
+    return buffer;
   }
-  return result;
+
+  // Fallback to Math.random when crypto is unavailable (e.g. certain test environments).
+  const fallbackBuffer = new Uint8Array(length);
+  for (let index = 0; index < length; index += 1) {
+    fallbackBuffer[index] = Math.floor(Math.random() * 256);
+  }
+  return fallbackBuffer;
+};
+
+export default function generateSeed(
+  length = DEFAULT_LENGTH,
+  characters = DEFAULT_CHARSET,
+): string {
+  if (!Number.isInteger(length) || length <= 0) {
+    throw new RangeError('generateSeed: length must be a positive integer');
+  }
+
+  if (!characters || characters.length === 0) {
+    throw new RangeError('generateSeed: characters cannot be empty');
+  }
+
+  const characterCount = characters.length;
+  const randomValues = getRandomValues(length);
+
+  return Array.from(randomValues, (value) =>
+    characters.charAt(value % characterCount),
+  ).join('');
 }

--- a/lib/i18n.ts
+++ b/lib/i18n.ts
@@ -1,0 +1,252 @@
+export const SUPPORTED_LANGUAGES = ['en', 'vi'] as const;
+
+export type LanguageKey = (typeof SUPPORTED_LANGUAGES)[number];
+
+export const DEFAULT_LANGUAGE: LanguageKey = 'en';
+
+const roleLabels: Record<LanguageKey, Record<string, string>> = {
+  en: {
+    Assassin: 'Assassin',
+    Fighter: 'Fighter',
+    Mage: 'Mage',
+    Marksman: 'Marksman',
+    Support: 'Support',
+    Tank: 'Tank',
+    Unknown: 'Unknown',
+  },
+  vi: {
+    Assassin: 'Sát thủ',
+    Fighter: 'Đấu sĩ',
+    Mage: 'Pháp sư',
+    Marksman: 'Xạ thủ',
+    Support: 'Hỗ trợ',
+    Tank: 'Đỡ đòn',
+    Unknown: 'Không xác định',
+  },
+};
+
+export type SeedActionsTranslations = {
+  seedLabel: string;
+  copyLink: string;
+  share: string;
+  copyMatchup: string;
+  clipboardUnavailable: string;
+  seedCopied: string;
+  seedCopyError: string;
+  matchupCopied: string;
+  matchupCopyError: string;
+  shareSuccess: string;
+  shareFailure: string;
+  shareTitle: string;
+  summary: {
+    seed: string;
+    championsPerTeam: string;
+    teamLabel: string;
+  };
+};
+
+export type TeamControlsTranslations = {
+  heading: string;
+  championsPerTeam: string;
+  decreaseAria: string;
+  increaseAria: string;
+  rangeAria: string;
+  helper: string;
+};
+
+export type TeamSummaryTranslations = {
+  heading: string;
+  uniqueRoles: string;
+  roleDistribution: string;
+  averageDifficulty: string;
+  roleLabels: Record<string, string>;
+};
+
+export type LanguageSelectorTranslations = {
+  label: string;
+  options: Record<LanguageKey, string>;
+};
+
+export type PageTranslations = {
+  title: string;
+  description: string;
+  teamLabel: string;
+  regenerate: string;
+  championCountLabel: string;
+  leftBadge: string;
+  rightBadge: string;
+};
+
+export type MatchupInsightsTranslations = {
+  heading: string;
+  helper: string;
+  leftLabel: string;
+  rightLabel: string;
+  metrics: {
+    attack: string;
+    defense: string;
+    magic: string;
+    difficulty: string;
+  };
+};
+
+export type Dictionary = {
+  page: PageTranslations;
+  seedActions: SeedActionsTranslations;
+  teamControls: TeamControlsTranslations;
+  teamSummary: TeamSummaryTranslations;
+  languageSelector: LanguageSelectorTranslations;
+  matchupInsights: MatchupInsightsTranslations;
+};
+
+export const DICTIONARY: Record<LanguageKey, Dictionary> = {
+  en: {
+    page: {
+      title: 'ARAM Random Team Generator',
+      description:
+        'Generate two colossal ARAM squads using a shared seed so your friends can reroll the exact same clash. Copy or share the current seed, or spin up a fresh one whenever inspiration strikes.',
+      teamLabel: 'Team',
+      regenerate: 'Regenerate',
+      championCountLabel: 'Champions',
+      leftBadge: 'Sun Team',
+      rightBadge: 'Moon Team',
+    },
+    seedActions: {
+      seedLabel: 'Seed',
+      copyLink: 'Copy link',
+      share: 'Share',
+      copyMatchup: 'Copy matchup',
+      clipboardUnavailable: 'Clipboard unavailable in this browser.',
+      seedCopied: 'Seed copied to clipboard!',
+      seedCopyError: 'Unable to copy seed. Please try again.',
+      matchupCopied: 'Matchup copied!',
+      matchupCopyError: 'Unable to copy matchup. Please try again.',
+      shareSuccess: 'Seed shared!',
+      shareFailure: 'Sharing failed. Try copying instead.',
+      shareTitle: 'ARAM Randomizer',
+      summary: {
+        seed: 'ARAM Seed',
+        championsPerTeam: 'Champions per team',
+        teamLabel: 'Team',
+      },
+    },
+    teamControls: {
+      heading: 'Team Options',
+      championsPerTeam: 'Champions per team',
+      decreaseAria: 'Decrease champions per team',
+      increaseAria: 'Increase champions per team',
+      rangeAria: 'Champions per team',
+      helper:
+        'Dial in anything from tight 10 champion crews to sprawling 20 pick drafts while keeping every seed instantly shareable.',
+    },
+    teamSummary: {
+      heading: 'Composition overview',
+      uniqueRoles: 'Unique roles',
+      roleDistribution: 'Role distribution',
+      averageDifficulty: 'Avg. difficulty',
+      roleLabels: roleLabels.en,
+    },
+    languageSelector: {
+      label: 'Language',
+      options: {
+        en: 'English',
+        vi: 'Tiếng Việt',
+      },
+    },
+    matchupInsights: {
+      heading: 'Matchup insights',
+      helper:
+        'Compare average attack, defense, magic, and difficulty to see which side leans into each stat.',
+      leftLabel: 'Sun Team',
+      rightLabel: 'Moon Team',
+      metrics: {
+        attack: 'Attack',
+        defense: 'Defense',
+        magic: 'Magic',
+        difficulty: 'Difficulty',
+      },
+    },
+  },
+  vi: {
+    page: {
+      title: 'Trình Tạo Đội ARAM Ngẫu Nhiên',
+      description:
+        'Tạo hai đội ARAM khổng lồ bằng cùng một hạt giống để cả nhóm cùng nhận kèo đại chiến. Sao chép hoặc chia sẻ hạt giống hiện tại, hoặc tạo mã mới bất cứ lúc nào.',
+      teamLabel: 'Đội',
+      regenerate: 'Tạo lại',
+      championCountLabel: 'Tướng',
+      leftBadge: 'Thái Dương',
+      rightBadge: 'Nguyệt Ảnh',
+    },
+    seedActions: {
+      seedLabel: 'Hạt giống',
+      copyLink: 'Sao chép liên kết',
+      share: 'Chia sẻ',
+      copyMatchup: 'Sao chép đội hình',
+      clipboardUnavailable: 'Trình duyệt này không hỗ trợ bảng tạm.',
+      seedCopied: 'Đã sao chép hạt giống!',
+      seedCopyError: 'Không thể sao chép hạt giống. Vui lòng thử lại.',
+      matchupCopied: 'Đã sao chép đội hình!',
+      matchupCopyError: 'Không thể sao chép đội hình. Vui lòng thử lại.',
+      shareSuccess: 'Đã chia sẻ hạt giống!',
+      shareFailure: 'Chia sẻ thất bại. Hãy thử sao chép.',
+      shareTitle: 'Bộ random ARAM',
+      summary: {
+        seed: 'Hạt giống ARAM',
+        championsPerTeam: 'Tướng mỗi đội',
+        teamLabel: 'Đội',
+      },
+    },
+    teamControls: {
+      heading: 'Tùy chọn đội',
+      championsPerTeam: 'Số tướng mỗi đội',
+      decreaseAria: 'Giảm số tướng mỗi đội',
+      increaseAria: 'Tăng số tướng mỗi đội',
+      rangeAria: 'Số tướng mỗi đội',
+      helper:
+        'Tùy chỉnh từ đội hình 10 tướng gọn nhẹ đến bản nháp 20 tướng hoành tráng mà vẫn chia sẻ hạt giống ngay lập tức.',
+    },
+    teamSummary: {
+      heading: 'Tổng quan đội hình',
+      uniqueRoles: 'Số vai trò khác nhau',
+      roleDistribution: 'Phân bố vai trò',
+      averageDifficulty: 'Độ khó trung bình',
+      roleLabels: roleLabels.vi,
+    },
+    languageSelector: {
+      label: 'Ngôn ngữ',
+      options: {
+        en: 'English',
+        vi: 'Tiếng Việt',
+      },
+    },
+    matchupInsights: {
+      heading: 'Phân tích kèo đấu',
+      helper:
+        'So sánh chỉ số trung bình về tấn công, phòng thủ, phép thuật và độ khó để xem đội nào vượt trội mỗi hạng mục.',
+      leftLabel: 'Thái Dương',
+      rightLabel: 'Nguyệt Ảnh',
+      metrics: {
+        attack: 'Tấn công',
+        defense: 'Phòng thủ',
+        magic: 'Phép thuật',
+        difficulty: 'Độ khó',
+      },
+    },
+  },
+};
+
+export const resolveLanguage = (rawLanguage?: string): LanguageKey => {
+  if (!rawLanguage) {
+    return DEFAULT_LANGUAGE;
+  }
+
+  const normalized = rawLanguage.toLowerCase();
+  if (normalized === 'vi') {
+    return 'vi';
+  }
+
+  return DEFAULT_LANGUAGE;
+};
+
+export const getDictionary = (language: LanguageKey) => DICTIONARY[language];

--- a/lib/static-champions.json
+++ b/lib/static-champions.json
@@ -1,0 +1,1036 @@
+[
+  {
+    "id": "Aatrox",
+    "key": "266",
+    "name": "Aatrox",
+    "title": "the Darkin Blade",
+    "blurb": "A fallen defender of Shurima returned as a living weapon.",
+    "info": {
+      "attack": 8,
+      "defense": 4,
+      "magic": 3,
+      "difficulty": 4
+    },
+    "image": {
+      "full": "Aatrox.png",
+      "sprite": "champion0.png",
+      "group": "champion",
+      "x": 0,
+      "y": 0,
+      "w": 48,
+      "h": 48
+    },
+    "tags": [
+      "Fighter",
+      "Tank"
+    ]
+  },
+  {
+    "id": "Ahri",
+    "key": "103",
+    "name": "Ahri",
+    "title": "the Nine-Tailed Fox",
+    "blurb": "A vastaya who can manipulate emotions and consume souls.",
+    "info": {
+      "attack": 3,
+      "defense": 4,
+      "magic": 8,
+      "difficulty": 5
+    },
+    "image": {
+      "full": "Ahri.png",
+      "sprite": "champion0.png",
+      "group": "champion",
+      "x": 48,
+      "y": 0,
+      "w": 48,
+      "h": 48
+    },
+    "tags": [
+      "Mage",
+      "Assassin"
+    ]
+  },
+  {
+    "id": "Akali",
+    "key": "84",
+    "name": "Akali",
+    "title": "the Rogue Assassin",
+    "blurb": "A rogue assassin striking from the shadows.",
+    "info": {
+      "attack": 5,
+      "defense": 3,
+      "magic": 8,
+      "difficulty": 7
+    },
+    "image": {
+      "full": "Akali.png",
+      "sprite": "champion0.png",
+      "group": "champion",
+      "x": 96,
+      "y": 0,
+      "w": 48,
+      "h": 48
+    },
+    "tags": [
+      "Assassin"
+    ]
+  },
+  {
+    "id": "Alistar",
+    "key": "12",
+    "name": "Alistar",
+    "title": "the Minotaur",
+    "blurb": "A mighty warrior who protects the downtrodden.",
+    "info": {
+      "attack": 6,
+      "defense": 9,
+      "magic": 5,
+      "difficulty": 7
+    },
+    "image": {
+      "full": "Alistar.png",
+      "sprite": "champion0.png",
+      "group": "champion",
+      "x": 144,
+      "y": 0,
+      "w": 48,
+      "h": 48
+    },
+    "tags": [
+      "Tank",
+      "Support"
+    ]
+  },
+  {
+    "id": "Amumu",
+    "key": "32",
+    "name": "Amumu",
+    "title": "the Sad Mummy",
+    "blurb": "A lonely soul forever searching for a friend.",
+    "info": {
+      "attack": 2,
+      "defense": 6,
+      "magic": 8,
+      "difficulty": 3
+    },
+    "image": {
+      "full": "Amumu.png",
+      "sprite": "champion0.png",
+      "group": "champion",
+      "x": 192,
+      "y": 0,
+      "w": 48,
+      "h": 48
+    },
+    "tags": [
+      "Tank",
+      "Mage"
+    ]
+  },
+  {
+    "id": "Annie",
+    "key": "1",
+    "name": "Annie",
+    "title": "the Dark Child",
+    "blurb": "A child with destructive pyromantic powers.",
+    "info": {
+      "attack": 2,
+      "defense": 3,
+      "magic": 10,
+      "difficulty": 6
+    },
+    "image": {
+      "full": "Annie.png",
+      "sprite": "champion0.png",
+      "group": "champion",
+      "x": 240,
+      "y": 0,
+      "w": 48,
+      "h": 48
+    },
+    "tags": [
+      "Mage"
+    ]
+  },
+  {
+    "id": "Ashe",
+    "key": "22",
+    "name": "Ashe",
+    "title": "the Frost Archer",
+    "blurb": "A stoic iceborn Warmother leading the Freljord.",
+    "info": {
+      "attack": 7,
+      "defense": 3,
+      "magic": 2,
+      "difficulty": 4
+    },
+    "image": {
+      "full": "Ashe.png",
+      "sprite": "champion0.png",
+      "group": "champion",
+      "x": 288,
+      "y": 0,
+      "w": 48,
+      "h": 48
+    },
+    "tags": [
+      "Marksman",
+      "Support"
+    ]
+  },
+  {
+    "id": "Braum",
+    "key": "201",
+    "name": "Braum",
+    "title": "the Heart of the Freljord",
+    "blurb": "A beloved hero armed with an enchanted door.",
+    "info": {
+      "attack": 3,
+      "defense": 8,
+      "magic": 4,
+      "difficulty": 5
+    },
+    "image": {
+      "full": "Braum.png",
+      "sprite": "champion1.png",
+      "group": "champion",
+      "x": 0,
+      "y": 0,
+      "w": 48,
+      "h": 48
+    },
+    "tags": [
+      "Support",
+      "Tank"
+    ]
+  },
+  {
+    "id": "Caitlyn",
+    "key": "51",
+    "name": "Caitlyn",
+    "title": "the Sheriff of Piltover",
+    "blurb": "Piltover's best shot and most cunning sheriff.",
+    "info": {
+      "attack": 8,
+      "defense": 2,
+      "magic": 2,
+      "difficulty": 4
+    },
+    "image": {
+      "full": "Caitlyn.png",
+      "sprite": "champion1.png",
+      "group": "champion",
+      "x": 48,
+      "y": 0,
+      "w": 48,
+      "h": 48
+    },
+    "tags": [
+      "Marksman"
+    ]
+  },
+  {
+    "id": "Darius",
+    "key": "122",
+    "name": "Darius",
+    "title": "the Hand of Noxus",
+    "blurb": "Noxus' most feared and respected commander.",
+    "info": {
+      "attack": 9,
+      "defense": 5,
+      "magic": 1,
+      "difficulty": 2
+    },
+    "image": {
+      "full": "Darius.png",
+      "sprite": "champion1.png",
+      "group": "champion",
+      "x": 96,
+      "y": 0,
+      "w": 48,
+      "h": 48
+    },
+    "tags": [
+      "Fighter",
+      "Tank"
+    ]
+  },
+  {
+    "id": "Ezreal",
+    "key": "81",
+    "name": "Ezreal",
+    "title": "the Prodigal Explorer",
+    "blurb": "A daring adventurer with arcane gauntlets.",
+    "info": {
+      "attack": 7,
+      "defense": 2,
+      "magic": 6,
+      "difficulty": 7
+    },
+    "image": {
+      "full": "Ezreal.png",
+      "sprite": "champion1.png",
+      "group": "champion",
+      "x": 144,
+      "y": 0,
+      "w": 48,
+      "h": 48
+    },
+    "tags": [
+      "Marksman",
+      "Mage"
+    ]
+  },
+  {
+    "id": "Garen",
+    "key": "86",
+    "name": "Garen",
+    "title": "The Might of Demacia",
+    "blurb": "A proud warrior of Demacia's elite Dauntless Vanguard.",
+    "info": {
+      "attack": 7,
+      "defense": 7,
+      "magic": 1,
+      "difficulty": 2
+    },
+    "image": {
+      "full": "Garen.png",
+      "sprite": "champion1.png",
+      "group": "champion",
+      "x": 192,
+      "y": 0,
+      "w": 48,
+      "h": 48
+    },
+    "tags": [
+      "Fighter",
+      "Tank"
+    ]
+  },
+  {
+    "id": "Jinx",
+    "key": "222",
+    "name": "Jinx",
+    "title": "the Loose Cannon",
+    "blurb": "A manic and impulsive criminal from Zaun.",
+    "info": {
+      "attack": 9,
+      "defense": 2,
+      "magic": 4,
+      "difficulty": 6
+    },
+    "image": {
+      "full": "Jinx.png",
+      "sprite": "champion1.png",
+      "group": "champion",
+      "x": 240,
+      "y": 0,
+      "w": 48,
+      "h": 48
+    },
+    "tags": [
+      "Marksman"
+    ]
+  },
+  {
+    "id": "Katarina",
+    "key": "55",
+    "name": "Katarina",
+    "title": "the Sinister Blade",
+    "blurb": "A Noxian assassin of the highest caliber.",
+    "info": {
+      "attack": 4,
+      "defense": 3,
+      "magic": 9,
+      "difficulty": 8
+    },
+    "image": {
+      "full": "Katarina.png",
+      "sprite": "champion1.png",
+      "group": "champion",
+      "x": 288,
+      "y": 0,
+      "w": 48,
+      "h": 48
+    },
+    "tags": [
+      "Assassin",
+      "Mage"
+    ]
+  },
+  {
+    "id": "Leona",
+    "key": "89",
+    "name": "Leona",
+    "title": "the Radiant Dawn",
+    "blurb": "A warrior imbued with the power of the sun.",
+    "info": {
+      "attack": 4,
+      "defense": 8,
+      "magic": 3,
+      "difficulty": 4
+    },
+    "image": {
+      "full": "Leona.png",
+      "sprite": "champion2.png",
+      "group": "champion",
+      "x": 0,
+      "y": 0,
+      "w": 48,
+      "h": 48
+    },
+    "tags": [
+      "Tank",
+      "Support"
+    ]
+  },
+  {
+    "id": "Lux",
+    "key": "99",
+    "name": "Lux",
+    "title": "the Lady of Luminosity",
+    "blurb": "A light mage of Demacia with boundless optimism.",
+    "info": {
+      "attack": 2,
+      "defense": 4,
+      "magic": 9,
+      "difficulty": 5
+    },
+    "image": {
+      "full": "Lux.png",
+      "sprite": "champion2.png",
+      "group": "champion",
+      "x": 48,
+      "y": 0,
+      "w": 48,
+      "h": 48
+    },
+    "tags": [
+      "Mage",
+      "Support"
+    ]
+  },
+  {
+    "id": "Morgana",
+    "key": "25",
+    "name": "Morgana",
+    "title": "the Fallen",
+    "blurb": "A fallen angel fighting for justice from the shadows.",
+    "info": {
+      "attack": 2,
+      "defense": 6,
+      "magic": 8,
+      "difficulty": 4
+    },
+    "image": {
+      "full": "Morgana.png",
+      "sprite": "champion2.png",
+      "group": "champion",
+      "x": 96,
+      "y": 0,
+      "w": 48,
+      "h": 48
+    },
+    "tags": [
+      "Mage",
+      "Support"
+    ]
+  },
+  {
+    "id": "Nami",
+    "key": "267",
+    "name": "Nami",
+    "title": "the Tidecaller",
+    "blurb": "A vastaya support wielding the power of the seas.",
+    "info": {
+      "attack": 4,
+      "defense": 3,
+      "magic": 7,
+      "difficulty": 5
+    },
+    "image": {
+      "full": "Nami.png",
+      "sprite": "champion2.png",
+      "group": "champion",
+      "x": 144,
+      "y": 0,
+      "w": 48,
+      "h": 48
+    },
+    "tags": [
+      "Support",
+      "Mage"
+    ]
+  },
+  {
+    "id": "Riven",
+    "key": "92",
+    "name": "Riven",
+    "title": "the Exile",
+    "blurb": "A swordmaster seeking redemption for her past.",
+    "info": {
+      "attack": 8,
+      "defense": 5,
+      "magic": 1,
+      "difficulty": 8
+    },
+    "image": {
+      "full": "Riven.png",
+      "sprite": "champion2.png",
+      "group": "champion",
+      "x": 192,
+      "y": 0,
+      "w": 48,
+      "h": 48
+    },
+    "tags": [
+      "Fighter",
+      "Assassin"
+    ]
+  },
+  {
+    "id": "Thresh",
+    "key": "412",
+    "name": "Thresh",
+    "title": "the Chain Warden",
+    "blurb": "A sadistic specter who harvests the souls of the living.",
+    "info": {
+      "attack": 5,
+      "defense": 6,
+      "magic": 6,
+      "difficulty": 7
+    },
+    "image": {
+      "full": "Thresh.png",
+      "sprite": "champion2.png",
+      "group": "champion",
+      "x": 240,
+      "y": 0,
+      "w": 48,
+      "h": 48
+    },
+    "tags": [
+      "Support",
+      "Fighter"
+    ]
+  },
+  {
+    "id": "Lux",
+    "key": "99",
+    "name": "Lux",
+    "title": "the Lady of Luminosity",
+    "blurb": "A mage who bends light into something to protect her kingdom.",
+    "info": {
+      "attack": 2,
+      "defense": 4,
+      "magic": 9,
+      "difficulty": 5
+    },
+    "image": {
+      "full": "Lux.png",
+      "sprite": "champion2.png",
+      "group": "champion",
+      "x": 192,
+      "y": 0,
+      "w": 48,
+      "h": 48
+    },
+    "tags": [
+      "Mage",
+      "Support"
+    ]
+  },
+  {
+    "id": "Malphite",
+    "key": "54",
+    "name": "Malphite",
+    "title": "Shard of the Monolith",
+    "blurb": "A massive creature made of living stone.",
+    "info": {
+      "attack": 5,
+      "defense": 9,
+      "magic": 7,
+      "difficulty": 3
+    },
+    "image": {
+      "full": "Malphite.png",
+      "sprite": "champion2.png",
+      "group": "champion",
+      "x": 240,
+      "y": 0,
+      "w": 48,
+      "h": 48
+    },
+    "tags": [
+      "Tank",
+      "Fighter"
+    ]
+  },
+  {
+    "id": "Morgana",
+    "key": "25",
+    "name": "Morgana",
+    "title": "Fallen Angel",
+    "blurb": "A fallen mage balancing darkness and light.",
+    "info": {
+      "attack": 1,
+      "defense": 6,
+      "magic": 8,
+      "difficulty": 3
+    },
+    "image": {
+      "full": "Morgana.png",
+      "sprite": "champion2.png",
+      "group": "champion",
+      "x": 288,
+      "y": 0,
+      "w": 48,
+      "h": 48
+    },
+    "tags": [
+      "Mage",
+      "Support"
+    ]
+  },
+  {
+    "id": "Nami",
+    "key": "267",
+    "name": "Nami",
+    "title": "the Tidecaller",
+    "blurb": "A tidecaller who commands the seas in the name of her people.",
+    "info": {
+      "attack": 4,
+      "defense": 3,
+      "magic": 7,
+      "difficulty": 5
+    },
+    "image": {
+      "full": "Nami.png",
+      "sprite": "champion3.png",
+      "group": "champion",
+      "x": 0,
+      "y": 0,
+      "w": 48,
+      "h": 48
+    },
+    "tags": [
+      "Support",
+      "Mage"
+    ]
+  },
+  {
+    "id": "Riven",
+    "key": "92",
+    "name": "Riven",
+    "title": "the Exile",
+    "blurb": "A Noxian exile wielding a reforged blade.",
+    "info": {
+      "attack": 8,
+      "defense": 5,
+      "magic": 1,
+      "difficulty": 8
+    },
+    "image": {
+      "full": "Riven.png",
+      "sprite": "champion3.png",
+      "group": "champion",
+      "x": 48,
+      "y": 0,
+      "w": 48,
+      "h": 48
+    },
+    "tags": [
+      "Fighter",
+      "Assassin"
+    ]
+  },
+  {
+    "id": "Sett",
+    "key": "875",
+    "name": "Sett",
+    "title": "the Boss",
+    "blurb": "A Piltovan pit fighter who took over Ionia's underground.",
+    "info": {
+      "attack": 8,
+      "defense": 5,
+      "magic": 1,
+      "difficulty": 2
+    },
+    "image": {
+      "full": "Sett.png",
+      "sprite": "champion3.png",
+      "group": "champion",
+      "x": 96,
+      "y": 0,
+      "w": 48,
+      "h": 48
+    },
+    "tags": [
+      "Fighter",
+      "Tank"
+    ]
+  },
+  {
+    "id": "Thresh",
+    "key": "412",
+    "name": "Thresh",
+    "title": "the Chain Warden",
+    "blurb": "A sadistic spirit jailer from the Shadow Isles.",
+    "info": {
+      "attack": 5,
+      "defense": 6,
+      "magic": 6,
+      "difficulty": 7
+    },
+    "image": {
+      "full": "Thresh.png",
+      "sprite": "champion3.png",
+      "group": "champion",
+      "x": 144,
+      "y": 0,
+      "w": 48,
+      "h": 48
+    },
+    "tags": [
+      "Support",
+      "Fighter"
+    ]
+  },
+  {
+    "id": "Vayne",
+    "key": "67",
+    "name": "Vayne",
+    "title": "the Night Hunter",
+    "blurb": "A deadly monster hunter armed with a crossbow.",
+    "info": {
+      "attack": 10,
+      "defense": 1,
+      "magic": 1,
+      "difficulty": 8
+    },
+    "image": {
+      "full": "Vayne.png",
+      "sprite": "champion3.png",
+      "group": "champion",
+      "x": 192,
+      "y": 0,
+      "w": 48,
+      "h": 48
+    },
+    "tags": [
+      "Marksman",
+      "Assassin"
+    ]
+  },
+  {
+    "id": "Yasuo",
+    "key": "157",
+    "name": "Yasuo",
+    "title": "the Unforgiven",
+    "blurb": "A wind technique master seeking redemption.",
+    "info": {
+      "attack": 8,
+      "defense": 4,
+      "magic": 4,
+      "difficulty": 10
+    },
+    "image": {
+      "full": "Yasuo.png",
+      "sprite": "champion3.png",
+      "group": "champion",
+      "x": 240,
+      "y": 0,
+      "w": 48,
+      "h": 48
+    },
+    "tags": [
+      "Fighter",
+      "Assassin"
+    ]
+  },
+  {
+    "id": "Zed",
+    "key": "238",
+    "name": "Zed",
+    "title": "the Master of Shadows",
+    "blurb": "A shadow warrior mastering forbidden techniques.",
+    "info": {
+      "attack": 9,
+      "defense": 2,
+      "magic": 1,
+      "difficulty": 7
+    },
+    "image": {
+      "full": "Zed.png",
+      "sprite": "champion3.png",
+      "group": "champion",
+      "x": 288,
+      "y": 0,
+      "w": 48,
+      "h": 48
+    },
+    "tags": [
+      "Assassin"
+    ]
+  },
+  {
+    "id": "Bard",
+    "key": "432",
+    "name": "Bard",
+    "title": "the Wandering Caretaker",
+    "blurb": "A cosmic caretaker who guides lost souls.",
+    "info": {
+      "attack": 4,
+      "defense": 5,
+      "magic": 7,
+      "difficulty": 9
+    },
+    "image": {
+      "full": "Bard.png",
+      "sprite": "champion3.png",
+      "group": "champion",
+      "x": 336,
+      "y": 0,
+      "w": 48,
+      "h": 48
+    },
+    "tags": [
+      "Support",
+      "Mage"
+    ]
+  },
+  {
+    "id": "Fizz",
+    "key": "105",
+    "name": "Fizz",
+    "title": "the Tidal Trickster",
+    "blurb": "An amphibious yordle trickster from the deep.",
+    "info": {
+      "attack": 6,
+      "defense": 4,
+      "magic": 7,
+      "difficulty": 6
+    },
+    "image": {
+      "full": "Fizz.png",
+      "sprite": "champion1.png",
+      "group": "champion",
+      "x": 240,
+      "y": 48,
+      "w": 48,
+      "h": 48
+    },
+    "tags": [
+      "Assassin",
+      "Fighter"
+    ]
+  },
+  {
+    "id": "Irelia",
+    "key": "39",
+    "name": "Irelia",
+    "title": "the Blade Dancer",
+    "blurb": "An Ionian blade master who dances with death.",
+    "info": {
+      "attack": 7,
+      "defense": 4,
+      "magic": 5,
+      "difficulty": 5
+    },
+    "image": {
+      "full": "Irelia.png",
+      "sprite": "champion2.png",
+      "group": "champion",
+      "x": 336,
+      "y": 48,
+      "w": 48,
+      "h": 48
+    },
+    "tags": [
+      "Fighter",
+      "Assassin"
+    ]
+  },
+  {
+    "id": "Jhin",
+    "key": "202",
+    "name": "Jhin",
+    "title": "the Virtuoso",
+    "blurb": "A meticulous criminal psychopath with a flair for drama.",
+    "info": {
+      "attack": 10,
+      "defense": 2,
+      "magic": 6,
+      "difficulty": 6
+    },
+    "image": {
+      "full": "Jhin.png",
+      "sprite": "champion2.png",
+      "group": "champion",
+      "x": 384,
+      "y": 0,
+      "w": 48,
+      "h": 48
+    },
+    "tags": [
+      "Marksman"
+    ]
+  },
+  {
+    "id": "Kaisa",
+    "key": "145",
+    "name": "Kai'Sa",
+    "title": "Daughter of the Void",
+    "blurb": "A survivor bonded with a living Void suit.",
+    "info": {
+      "attack": 8,
+      "defense": 5,
+      "magic": 3,
+      "difficulty": 6
+    },
+    "image": {
+      "full": "Kaisa.png",
+      "sprite": "champion3.png",
+      "group": "champion",
+      "x": 384,
+      "y": 0,
+      "w": 48,
+      "h": 48
+    },
+    "tags": [
+      "Marksman",
+      "Assassin"
+    ]
+  },
+  {
+    "id": "Katarina",
+    "key": "55",
+    "name": "Katarina",
+    "title": "the Sinister Blade",
+    "blurb": "A Noxian assassin famed for her lethal blades.",
+    "info": {
+      "attack": 4,
+      "defense": 3,
+      "magic": 9,
+      "difficulty": 8
+    },
+    "image": {
+      "full": "Katarina.png",
+      "sprite": "champion2.png",
+      "group": "champion",
+      "x": 432,
+      "y": 0,
+      "w": 48,
+      "h": 48
+    },
+    "tags": [
+      "Assassin",
+      "Mage"
+    ]
+  },
+  {
+    "id": "Kassadin",
+    "key": "38",
+    "name": "Kassadin",
+    "title": "the Void Walker",
+    "blurb": "A seeker of forbidden knowledge bent on destroying the Void.",
+    "info": {
+      "attack": 3,
+      "defense": 5,
+      "magic": 8,
+      "difficulty": 8
+    },
+    "image": {
+      "full": "Kassadin.png",
+      "sprite": "champion2.png",
+      "group": "champion",
+      "x": 480,
+      "y": 0,
+      "w": 48,
+      "h": 48
+    },
+    "tags": [
+      "Assassin",
+      "Mage"
+    ]
+  },
+  {
+    "id": "Rakan",
+    "key": "497",
+    "name": "Rakan",
+    "title": "the Charmer",
+    "blurb": "A flamboyant vastayan performer fighting for freedom.",
+    "info": {
+      "attack": 3,
+      "defense": 4,
+      "magic": 8,
+      "difficulty": 5
+    },
+    "image": {
+      "full": "Rakan.png",
+      "sprite": "champion4.png",
+      "group": "champion",
+      "x": 0,
+      "y": 0,
+      "w": 48,
+      "h": 48
+    },
+    "tags": [
+      "Support",
+      "Mage"
+    ]
+  },
+  {
+    "id": "Sona",
+    "key": "37",
+    "name": "Sona",
+    "title": "Maven of the Strings",
+    "blurb": "A virtuoso who communicates with strings and melodies.",
+    "info": {
+      "attack": 5,
+      "defense": 2,
+      "magic": 8,
+      "difficulty": 4
+    },
+    "image": {
+      "full": "Sona.png",
+      "sprite": "champion4.png",
+      "group": "champion",
+      "x": 48,
+      "y": 0,
+      "w": 48,
+      "h": 48
+    },
+    "tags": [
+      "Support",
+      "Mage"
+    ]
+  },
+  {
+    "id": "Volibear",
+    "key": "106",
+    "name": "Volibear",
+    "title": "the Relentless Storm",
+    "blurb": "A demigod of thunder embodying the ferocity of the Freljord.",
+    "info": {
+      "attack": 7,
+      "defense": 7,
+      "magic": 4,
+      "difficulty": 3
+    },
+    "image": {
+      "full": "Volibear.png",
+      "sprite": "champion4.png",
+      "group": "champion",
+      "x": 96,
+      "y": 0,
+      "w": 48,
+      "h": 48
+    },
+    "tags": [
+      "Fighter",
+      "Tank"
+    ]
+  }
+]


### PR DESCRIPTION
## Summary
- update the champion grid to use auto-fit columns so cards no longer collide at wider breakpoints
- refresh champion card spacing, shadows, and badge styling for a cleaner presentation across languages

## Testing
- yarn build

------
https://chatgpt.com/codex/tasks/task_e_68e16dc82ba0832298e9449ee6d8cf87